### PR TITLE
Add volumes to persist db data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+esdata
+pgdata

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
     image: elasticsearch:5-alpine
     volumes:
       - ./contrib:/usr/share/elasticsearch/config/scripts
+      - ./esdata:/usr/share/elasticsearch/data
     restart: always
 
   postgres:
@@ -55,6 +56,8 @@ services:
     environment:
       - POSTGRES_USER=timesketch
       - POSTGRES_PASSWORD=password
+    volumes:
+      - ./pgdata:/var/lib/postgresql/data
     restart: always
 
   redis:


### PR DESCRIPTION
Volumes were added to postgres and elasticsearch containers to persist database data and survive `docker-compose down`

Address #6